### PR TITLE
Espn api identification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-./node_modules
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "sportsscoreboard",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/CS465-565-Fall19-Group-Project/SportsScoreboard/issues"
   },
-  "homepage": "https://github.com/CS465-565-Fall19-Group-Project/SportsScoreboard#readme"
+  "homepage": "https://github.com/CS465-565-Fall19-Group-Project/SportsScoreboard#readme",
+  "dependencies": {
+    "axios": "^0.19.0"
+  }
 }

--- a/scripts/apis.js
+++ b/scripts/apis.js
@@ -1,5 +1,8 @@
+//SOURCE: https://gist.github.com/akeaswaran/b48b02f1c94f873c6655e7129910fc3b
+
 //File containing API calls to get score data
 const axios = require("axios");
+const ESPNObjects = require("./sdk/espn_classes.js");
 
 /**
  * Method to convert a Date object into string form 'YYYYMMDD' required for ESPN API parameters
@@ -34,8 +37,8 @@ const get_data = async (uri, params) => {
     });
 };
 
-const get_scores = async (sport, league) => {
-  const uri = `http://site.api.espn.com/apis/site/v2/sports/${sport}/${league.replace(
+const get_scoreboard = async (sport, league) => {
+  const uri = `https://site.api.espn.com/apis/site/v2/sports/${sport}/${league.replace(
     /\\s/gi,
     "-"
   )}/scoreboard`;
@@ -43,19 +46,43 @@ const get_scores = async (sport, league) => {
     calendar: "blacklist",
     dates: get_date_string(new Date())
   };
-  console.log(uri);
-  console.log(params);
 
-  return await get_data(uri, params);
+  const scoreboard = await get_data(uri, params);
+  if (scoreboard != null) {
+    return new ESPNObjects.ESPNScoreboard().init(scoreboard);
+  } else {
+    console.log(
+      `Cannot get scoreboard for sport=${sport} and league=${league}`
+    );
+    return null;
+  }
+};
+
+const get_schedule = async (sport, league, team) => {
+  const uri = `https://site.api.espn.com/apis/site/v2/sports/${sport}/${league.replace(
+    /\\s/gi,
+    "-"
+  )}/teams/${team}/schedule`;
+  const params = {};
+
+  const scoreboard = await get_data(uri, params);
+  if (scoreboard != null) {
+    return new ESPNObjects.ESPNScoreboard().init(scoreboard);
+  } else {
+    console.log(
+      `Cannot get scoreboard for sport=${sport} and league=${league}`
+    );
+    return null;
+  }
 };
 
 let uri =
-  "http://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard";
-const params = {
-  calendar: "blacklist",
-  dates: "20191105"
-};
-const data = get_scores("basketball", "nba").then(output => {
-  console.log(output);
-  //console.log(output.events[0].competitions[0].competitors);
+  "http://site.api.espn.com/apis/site/v2/sports/football/college-football/teams/ore/schedule";
+const params = {};
+const data = get_scoreboard("football", "college-football").then(output => {
+  /*output.events.forEach(element => {
+    console.log(element.competitions[0]);
+  });*/
+  let scoreboard = new ESPNObjects.ESPNScoreboard().init(output);
+  console.log(scoreboard.events[0].competitions[0].competitors[0]);
 });

--- a/scripts/apis.js
+++ b/scripts/apis.js
@@ -65,12 +65,12 @@ const get_schedule = async (sport, league, team) => {
   )}/teams/${team}/schedule`;
   const params = {};
 
-  const scoreboard = await get_data(uri, params);
-  if (scoreboard != null) {
-    return new ESPNObjects.ESPNScoreboard().init(scoreboard);
+  const schedule = await get_data(uri, params);
+  if (schedule != null) {
+    return new ESPNObjects.ESPNTeamSchedule().init(schedule);
   } else {
     console.log(
-      `Cannot get scoreboard for sport=${sport} and league=${league}`
+      `Cannot get schedule for sport=${sport}, league=${league}, and team=${team}`
     );
     return null;
   }
@@ -79,10 +79,6 @@ const get_schedule = async (sport, league, team) => {
 let uri =
   "http://site.api.espn.com/apis/site/v2/sports/football/college-football/teams/ore/schedule";
 const params = {};
-const data = get_scoreboard("football", "college-football").then(output => {
-  /*output.events.forEach(element => {
-    console.log(element.competitions[0]);
-  });*/
-  let scoreboard = new ESPNObjects.ESPNScoreboard().init(output);
-  console.log(scoreboard.events[0].competitions[0].competitors[0]);
+const data = get_schedule("basketball", "nba", "portland").then(output => {
+  console.log(output);
 });

--- a/scripts/apis.js
+++ b/scripts/apis.js
@@ -1,0 +1,61 @@
+//File containing API calls to get score data
+const axios = require("axios");
+
+/**
+ * Method to convert a Date object into string form 'YYYYMMDD' required for ESPN API parameters
+ * @param {object} Date object to convert
+ */
+const get_date_string = date => {
+  return date
+    .toISOString()
+    .split("T")[0]
+    .replace(/-/gi, "");
+};
+
+/**
+ *
+ * @param {string} uri  URI string or request
+ * @param {object} params JSON object mapping query parameter to a value (e.g. { foo: bar, foo2: baz })
+ */
+const get_data = async (uri, params) => {
+  const options = {
+    method: "get",
+    url: uri,
+    params: params,
+    responseType: "json"
+  };
+  return await axios(options)
+    .then(resp => {
+      return resp.data;
+    })
+    .catch(err => {
+      console.log(`Error processing request: ${err}`);
+      return null;
+    });
+};
+
+const get_scores = async (sport, league) => {
+  const uri = `http://site.api.espn.com/apis/site/v2/sports/${sport}/${league.replace(
+    /\\s/gi,
+    "-"
+  )}/scoreboard`;
+  const params = {
+    calendar: "blacklist",
+    dates: get_date_string(new Date())
+  };
+  console.log(uri);
+  console.log(params);
+
+  return await get_data(uri, params);
+};
+
+let uri =
+  "http://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard";
+const params = {
+  calendar: "blacklist",
+  dates: "20191105"
+};
+const data = get_scores("basketball", "nba").then(output => {
+  console.log(output);
+  //console.log(output.events[0].competitions[0].competitors);
+});

--- a/scripts/sdk/espn_classes.js
+++ b/scripts/sdk/espn_classes.js
@@ -233,6 +233,8 @@ class ESPNCompetitor {
 
 module.exports = {
   ESPNScoreboard,
+  ESPNTeamSchedule,
+  ESPNTeam,
   ESPNLeague,
   ESPNEvent,
   ESPNCompetition,

--- a/scripts/sdk/espn_classes.js
+++ b/scripts/sdk/espn_classes.js
@@ -1,0 +1,147 @@
+class ESPNScoreboard {
+  /**
+   * @constructor
+   * @property {ESPNLeague[]} leagues
+   * @property {ESPNEvent[]} events
+   */
+  constructor() {
+    this.leagues = [];
+    this.events = [];
+  }
+
+  init(api_data) {
+    this.leagues = api_data.leagues.map(obj => new ESPNLeague().init(obj));
+    this.events = api_data.events.map(obj => new ESPNEvent().init(obj));
+    return this;
+  }
+}
+
+class ESPNLeague {
+  /**
+   * @constructor
+   * @property {string[]} calendars Array of UTC string  representing days in which league has games
+   */
+  constructor() {
+    this.id = "";
+    this.uid = "";
+    this.name = "";
+    this.abbreviation = "";
+    this.slug = "";
+    this.season = {};
+    this.calendarType = "";
+    this.calendarIsWhitelist = true;
+    this.calendarStartDate = new Date().toUTCString();
+    this.calendarEndDate = new Date().toUTCString();
+    this.calendar = [];
+  }
+
+  init(data) {
+    Object.assign(this, data);
+    return this;
+  }
+}
+
+class ESPNEvent {
+  constructor() {
+    this.id = "";
+    this.uid = "";
+    this.name = "";
+    this.shortName = "";
+    this.season = {};
+    this.competitions = [];
+    this.links = [];
+    this.status = {};
+  }
+
+  init(data) {
+    Object.assign(this, data);
+    this.competitions = data.competitions.map(obj =>
+      new ESPNCompetition().init(obj)
+    );
+    this.status = new ESPNEventStatus().init(data.status);
+    return this;
+  }
+}
+
+class ESPNCompetition {
+  constructor() {
+    this.id = "";
+    this.uid = "";
+    this.date = "";
+    this.attendance = "";
+    this.type = {};
+    this.timeValid = true;
+    this.neutralSite = false;
+    this.conferenceCompetition = false;
+    this.recent = false;
+    this.venue = {};
+    this.competitors = [];
+    this.notes = [];
+    this.status = {};
+    this.broadcasts = [];
+    this.tickets = [];
+    this.startDate = "";
+    this.geoBroadcasts = [];
+    this.odds = [];
+  }
+
+  init(data) {
+    Object.assign(this, data);
+    this.competitors = data.competitors.map(obj =>
+      new ESPNCompetitor().init(obj)
+    );
+    this.status = new ESPNEventStatus().init(data.status);
+    return this;
+  }
+}
+
+class ESPNEventStatus {
+  constructor() {
+    this.clock = 0;
+    this.displayClock = "";
+    this.period = 0;
+    this.type = {
+      id: "",
+      name: "",
+      state: "",
+      completed: false,
+      description: "",
+      detail: "",
+      shortDetail: ""
+    };
+  }
+
+  init(data) {
+    Object.assign(this, data);
+    return this;
+  }
+}
+
+class ESPNCompetitor {
+  constructor() {
+    this.id = "";
+    this.uid = "";
+    this.type = "team";
+    this.order = 0;
+    this.homeAway = "home";
+    this.team = {};
+    this.score = "";
+    this.statistics = [];
+    this.records = [];
+    this.leaders = [];
+  }
+
+  init(data) {
+    Object.assign(this, data);
+    return this;
+  }
+}
+
+module.exports = {
+  ESPNScoreboard,
+  ESPNLeague,
+  ESPNEvent,
+  ESPNCompetition,
+  ESPNEventStatus,
+  ESPNCompetitor
+};

--- a/scripts/sdk/espn_classes.js
+++ b/scripts/sdk/espn_classes.js
@@ -14,6 +14,70 @@ class ESPNScoreboard {
     this.events = api_data.events.map(obj => new ESPNEvent().init(obj));
     return this;
   }
+
+  getEventsByCompetitor(searchString) {
+    return this.events.filter(event => {
+      return event.has_competitor(searchString);
+    });
+  }
+}
+
+class ESPNTeamSchedule {
+  constructor() {
+    this.timestamp = "";
+    this.status = "";
+    this.season = {};
+    this.team = {};
+    this.events = [];
+    this.requestedSeason = {};
+  }
+
+  init(api_data) {
+    Object.assign(this, api_data);
+    //this.events = api_data.events.map(obj => new ESPNEvent().init(obj));
+    return this;
+  }
+
+  getEventsByCompetitor(searchString) {
+    return this.events.filter(event => {
+      return event.has_competitor(searchString);
+    });
+  }
+}
+
+class ESPNTeam {
+  /**
+   * @constructor
+   * @property {ESPNLeague[]} leagues
+   * @property {ESPNEvent[]} events
+   */
+  constructor() {
+    this.id = "";
+    this.abbreviation = "";
+    this.location = "";
+    this.name = "";
+    this.displayName = "";
+    this.venueLink = "";
+    this.clubhouse = "";
+    this.color = "";
+    this.logo = "";
+    this.recordSummary = "";
+    this.seasonSummary = "";
+    this.standingsSummary = "";
+    groups = {};
+  }
+
+  init(api_data) {
+    Object.assign(this, api_data);
+    this.events = api_data.events.map(obj => new ESPNEvent().init(obj));
+    return this;
+  }
+
+  getEventsByCompetitor(searchString) {
+    return this.events.filter(event => {
+      return event.has_competitor(searchString);
+    });
+  }
 }
 
 class ESPNLeague {
@@ -61,6 +125,15 @@ class ESPNEvent {
     this.status = new ESPNEventStatus().init(data.status);
     return this;
   }
+
+  has_competitor(name) {
+    this.competitions.forEach(competitions => {
+      if (competitions.has_competitor(name)) {
+        return true;
+      }
+    });
+    return false;
+  }
 }
 
 class ESPNCompetition {
@@ -92,6 +165,15 @@ class ESPNCompetition {
     );
     this.status = new ESPNEventStatus().init(data.status);
     return this;
+  }
+
+  has_competitor(name) {
+    this.competitors.forEach(competitor => {
+      if (competitor.is_match(name)) {
+        return true;
+      }
+    });
+    return false;
   }
 }
 
@@ -134,6 +216,18 @@ class ESPNCompetitor {
   init(data) {
     Object.assign(this, data);
     return this;
+  }
+
+  /**
+   * Method to determine if competitor is a match for search string.
+   * Looks for partial match in full name or exact match for abbreviation
+   * @param {string} searchString
+   */
+  is_match(searchString) {
+    return (
+      this.team.displayName.includes(searchString) ||
+      this.team.abbreviation === searchString
+    );
   }
 }
 


### PR DESCRIPTION
Goal of this PR was to explore ways to use ESPN APIs to pull data and organize a setup for this. Work completed:

* Added `axios` as a dependency for making HTTP requests to API urls (mostly a comfort thing because I've used it before, but also Promise based which might be useful)
* Created SDK objects for the response objects to relevant API calls. Basically trying to do something a little more OOP and make it easier to see what data is coming back from calls. Documentation is light and there may be additional work because different calls return similar by slightly different objects.
* Created `scripts/apis.js` file to house all API calls.
    * `get_data` is generic method using `axios` to make an API call
    * `get_scoreboard` returns today's scoreboard for a sport/league
    * `get_schedule` will get schedule for a team

Also note that there are some limitations - schedule api structure I figured out doesn't work for soccer events (and potentially others) because I don't think ESPN hosts full schedules for those leagues